### PR TITLE
matching changes for edge-proto reorg

### DIFF
--- a/EmptyMatchEngineApp/THIRD_PARTY_LICENSES.txt
+++ b/EmptyMatchEngineApp/THIRD_PARTY_LICENSES.txt
@@ -2752,11 +2752,11 @@ Package: Activity
 License:
 http://www.apache.org/licenses/LICENSE-2.0.txt
 ================================================================================
-Package: Android Support Library fragment
+Package: Android Support CardView v7
 License:
 http://www.apache.org/licenses/LICENSE-2.0.txt
 ================================================================================
-Package: Android Support CardView v7
+Package: Android Support Library fragment
 License:
 http://www.apache.org/licenses/LICENSE-2.0.txt
 ================================================================================
@@ -3846,7 +3846,7 @@ EXHIBIT A-Netscape Public License.
 
 
     Alternatively, the contents of this file may be used under the
-    terms of the _____ license (the ���[___] License���), in which case
+    terms of the _____ license (the ???[___] License???), in which case
     the provisions of [______] License are applicable instead of those
     above.  If you wish to allow use of your version of this file only
     under the terms of the [____] License and not to allow others to
@@ -4325,7 +4325,7 @@ Version 1.1
 13. MULTIPLE-LICENSED CODE.
 
     Initial Developer may designate portions of the Covered Code as
-    ���Multiple-Licensed���.  ���Multiple-Licensed��� means that the Initial
+    ???Multiple-Licensed???.  ???Multiple-Licensed??? means that the Initial
     Developer permits you to utilize portions of the Covered Code
     under Your choice of the NPL or the alternative licenses, if any,
     specified by the Initial Developer in the file described in
@@ -4354,7 +4354,7 @@ EXHIBIT A -Mozilla Public License.
     Contributor(s): ______________________________________.
 
     Alternatively, the contents of this file may be used under the
-    terms of the _____ license (the ���[___] License���), in which case
+    terms of the _____ license (the ???[___] License???), in which case
     the provisions of [______] License are applicable instead of those
     above.  If you wish to allow use of your version of this file only
     under the terms of the [____] License and not to allow others to
@@ -5719,11 +5719,11 @@ Package: perfmark:perfmark-api
 License:
 https://opensource.org/licenses/Apache-2.0
 ================================================================================
-Package: Android Support Library collections
+Package: Android Lifecycle LiveData Core
 License:
 http://www.apache.org/licenses/LICENSE-2.0.txt
 ================================================================================
-Package: Android Lifecycle LiveData Core
+Package: Android Support Library collections
 License:
 http://www.apache.org/licenses/LICENSE-2.0.txt
 ================================================================================
@@ -5763,13 +5763,13 @@ Package: Android Support Library Interpolators
 License:
 http://www.apache.org/licenses/LICENSE-2.0.txt
 ================================================================================
-Package: J2ObjC Annotations
-License:
-http://www.apache.org/licenses/LICENSE-2.0.txt
-================================================================================
 Package: Google Android Annotations Library
 License:
 http://www.apache.org/licenses/LICENSE-2.0
+================================================================================
+Package: J2ObjC Annotations
+License:
+http://www.apache.org/licenses/LICENSE-2.0.txt
 ================================================================================
 Package: Checker Qual
 License:
@@ -5811,11 +5811,15 @@ Package: io.grpc:grpc-stub
 License:
 https://opensource.org/licenses/Apache-2.0
 ================================================================================
+Package: Android Resources Library
+License:
+http://www.apache.org/licenses/LICENSE-2.0.txt
+================================================================================
 Package: error-prone annotations
 License:
 http://www.apache.org/licenses/LICENSE-2.0.txt
 ================================================================================
-Package: Android Resources Library
+Package: Android Support Library core utils
 License:
 http://www.apache.org/licenses/LICENSE-2.0.txt
 ================================================================================
@@ -5998,7 +6002,7 @@ Package: ICU4C
 License:
 COPYRIGHT AND PERMISSION NOTICE (ICU 58 and later)
 
-Copyright �� 1991-2017 Unicode, Inc. All rights reserved.
+Copyright ?? 1991-2017 Unicode, Inc. All rights reserved.
 Distributed under the Terms of Use in http://www.unicode.org/copyright.html
 
 Permission is hereby granted, free of charge, to any person obtaining
@@ -6428,10 +6432,6 @@ Redistribution and use in source and binary forms, with or without modification,
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ================================================================================
-Package: Android Support Library core utils
-License:
-http://www.apache.org/licenses/LICENSE-2.0.txt
-================================================================================
 Package: Android Support Library Custom View
 License:
 http://www.apache.org/licenses/LICENSE-2.0.txt
@@ -6460,11 +6460,11 @@ Package: Android ConstraintLayout
 License:
 http://www.apache.org/licenses/LICENSE-2.0.txt
 ================================================================================
-Package: Android Support Library compat
+Package: Android App Startup Runtime
 License:
 http://www.apache.org/licenses/LICENSE-2.0.txt
 ================================================================================
-Package: Android App Startup Runtime
+Package: Android Support Library compat
 License:
 http://www.apache.org/licenses/LICENSE-2.0.txt
 ================================================================================

--- a/EmptyMatchEngineApp/app/src/main/AndroidManifest.xml
+++ b/EmptyMatchEngineApp/app/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
         <!-- Extra launcher for First Time Use UI -->
         <activity
             android:name="com.mobiledgex.sdkdemo.SettingsActivity"
+            android:exported="true"
             android:label="@string/title_activity_settings" />
         <activity
             android:exported="true"

--- a/EmptyMatchEngineApp/app/src/main/java/com/mobiledgex/sdkdemo/MainActivity.java
+++ b/EmptyMatchEngineApp/app/src/main/java/com/mobiledgex/sdkdemo/MainActivity.java
@@ -71,6 +71,8 @@ import java.util.concurrent.Future;
 
 import distributed_match_engine.AppClient;
 import distributed_match_engine.Appcommon;
+import distributed_match_engine.Locverify;
+import distributed_match_engine.SessionOuterClass;
 import io.grpc.StatusRuntimeException;
 
 public class MainActivity extends AppCompatActivity implements SharedPreferences.OnSharedPreferenceChangeListener {
@@ -710,7 +712,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
 
             // Use createDefaultRegisterClientRequest() to get a Builder class to fill in optional parameters
             // like AuthToken or Tag key value pairs.
-            AppClient.RegisterClientRequest registerClientRequest =
+            SessionOuterClass.RegisterClientRequest registerClientRequest =
                     me.createDefaultRegisterClientRequest(ctx, orgName)
                             //.setCarrierName("cerust")
                             .setAppName(appName)
@@ -719,15 +721,15 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
             Log.i(TAG, "registerclient request is " + registerClientRequest);
 
             // This exercises a threadpool that can have a dependent call depth larger than 1
-            AppClient.RegisterClientReply registerClientReply;
-            Future<AppClient.RegisterClientReply> registerClientReplyFuture =
+            SessionOuterClass.RegisterClientReply registerClientReply;
+            Future<SessionOuterClass.RegisterClientReply> registerClientReplyFuture =
                     me.registerClientFuture(registerClientRequest,
                             dmeHostAddress, port, 10000);
             registerClientReply = registerClientReplyFuture.get();
 
             Log.i(TAG, "RegisterReply status is " + registerClientReply.getStatus());
 
-            if (registerClientReply.getStatus() != AppClient.ReplyStatus.RS_SUCCESS) {
+            if (registerClientReply.getStatus() != Appcommon.ReplyStatus.RS_SUCCESS) {
                 someText += "Registration Failed. Error: " + registerClientReply.getStatus();
                 return;
             }
@@ -757,14 +759,14 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                             dmeHostAddress, port, 10000);
             registerClientReply = registerClientReplyFuture.get();
             Log.i(TAG, "Register status: " + registerClientReply.getStatus());
-            AppClient.VerifyLocationRequest verifyRequest =
+            Locverify.VerifyLocationRequest verifyRequest =
                     me.createDefaultVerifyLocationRequest(ctx, location)
                             .build();
             Log.i(TAG, "verifyRequest is " + verifyRequest);
 
             if (verifyRequest != null) {
                 // Location Verification (Blocking, or use verifyLocationFuture):
-                AppClient.VerifyLocationReply verifiedLocation =
+                Locverify.VerifyLocationReply verifiedLocation =
                         me.verifyLocation(verifyRequest, dmeHostAddress, port, 10000);
                 Log.i(TAG, "VerifyLocationReply is " + verifiedLocation);
 

--- a/EmptyMatchEngineApp/matchingengine/src/androidTest/java/com/mobiledgex/matchingengine/EdgeEventsConnectionTest.java
+++ b/EmptyMatchEngineApp/matchingengine/src/androidTest/java/com/mobiledgex/matchingengine/EdgeEventsConnectionTest.java
@@ -68,6 +68,7 @@ import java.util.concurrent.TimeUnit;
 import distributed_match_engine.AppClient;
 import distributed_match_engine.Appcommon;
 import distributed_match_engine.LocOuterClass;
+import distributed_match_engine.SessionOuterClass;
 
 import static com.mobiledgex.matchingengine.EdgeEventsConnection.ChannelStatus.open;
 import static com.mobiledgex.matchingengine.EdgeEventsConnection.ChannelStatus.opening;
@@ -192,12 +193,12 @@ public class EdgeEventsConnectionTest {
     public void registerClient(MatchingEngine me) {
         Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
-        AppClient.RegisterClientReply registerReply;
-        AppClient.RegisterClientRequest regRequest;
+        SessionOuterClass.RegisterClientReply registerReply;
+        SessionOuterClass.RegisterClientRequest regRequest;
 
         try {
             // The app version will be null, but we can build from scratch for test
-            AppClient.RegisterClientRequest.Builder regRequestBuilder = AppClient.RegisterClientRequest.newBuilder()
+            SessionOuterClass.RegisterClientRequest.Builder regRequestBuilder = SessionOuterClass.RegisterClientRequest.newBuilder()
                     .setOrgName(organizationName)
                     .setAppName(applicationName)
                     .setAppVers(appVersion);
@@ -209,7 +210,7 @@ public class EdgeEventsConnectionTest {
             }
             assertEquals("Response SessionCookie should equal MatchingEngine SessionCookie",
                     registerReply.getSessionCookie(), me.getSessionCookie());
-            assertSame(registerReply.getStatus(), AppClient.ReplyStatus.RS_SUCCESS);
+            assertSame(registerReply.getStatus(), Appcommon.ReplyStatus.RS_SUCCESS);
         } catch (DmeDnsException dde) {
             Log.e(TAG, Log.getStackTraceString(dde));
             fail("ExecutionException registering client.");

--- a/EmptyMatchEngineApp/matchingengine/src/androidTest/java/com/mobiledgex/matchingengine/EngineCallTest.java
+++ b/EmptyMatchEngineApp/matchingengine/src/androidTest/java/com/mobiledgex/matchingengine/EngineCallTest.java
@@ -81,6 +81,10 @@ import java.util.concurrent.TimeoutException;
 import distributed_match_engine.AppClient;
 import distributed_match_engine.Appcommon;
 import distributed_match_engine.Appcommon.AppPort;
+import distributed_match_engine.DynamicLocationGroup;
+import distributed_match_engine.Locverify;
+import distributed_match_engine.QosPositionOuterClass;
+import distributed_match_engine.SessionOuterClass;
 import io.grpc.StatusRuntimeException;
 
 import static junit.framework.TestCase.assertNotNull;
@@ -302,7 +306,7 @@ public class EngineCallTest {
             Location location = meLoc.getBlocking(context, GRPC_TIMEOUT_MS);
 
             //! [createdefregisterexample]
-            AppClient.RegisterClientRequest registerClientRequest = me.createDefaultRegisterClientRequest(context, organizationName).build();
+            SessionOuterClass.RegisterClientRequest registerClientRequest = me.createDefaultRegisterClientRequest(context, organizationName).build();
             //! [createdefregisterexample]
             assertTrue(registerClientRequest == null);
 
@@ -317,11 +321,11 @@ public class EngineCallTest {
                     .build();
             assertTrue(findCloudletRequest == null);
 
-            AppClient.GetLocationRequest locationRequest = me.createDefaultGetLocationRequest(context).build();
+            Locverify.GetLocationRequest locationRequest = me.createDefaultGetLocationRequest(context).build();
             assertTrue(locationRequest == null);
 
             //! [createdefverifylocationexample]
-            AppClient.VerifyLocationRequest verifyLocationRequest = me.createDefaultVerifyLocationRequest(context, location).build();
+            Locverify.VerifyLocationRequest verifyLocationRequest = me.createDefaultVerifyLocationRequest(context, location).build();
             //! [createdefverifylocationexample]
             assertTrue(verifyLocationRequest == null);
 
@@ -362,12 +366,12 @@ public class EngineCallTest {
     public void registerClient(MatchingEngine me) {
         Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
-        AppClient.RegisterClientReply registerReply;
-        AppClient.RegisterClientRequest registerClientRequest;
+        SessionOuterClass.RegisterClientReply registerReply;
+        SessionOuterClass.RegisterClientRequest registerClientRequest;
 
         try {
             // The app version will be null, but we can build from scratch for test
-            AppClient.RegisterClientRequest.Builder regRequestBuilder = AppClient.RegisterClientRequest.newBuilder()
+            SessionOuterClass.RegisterClientRequest.Builder regRequestBuilder = SessionOuterClass.RegisterClientRequest.newBuilder()
                     .setOrgName(organizationName)
                     .setAppName(applicationName)
                     .setAppVers(appVersion);
@@ -383,7 +387,7 @@ public class EngineCallTest {
             }
             assertEquals("Response SessionCookie should equal MatchingEngine SessionCookie",
                     registerReply.getSessionCookie(), me.getSessionCookie());
-            assertTrue(registerReply.getStatus() == AppClient.ReplyStatus.RS_SUCCESS);
+            assertTrue(registerReply.getStatus() == Appcommon.ReplyStatus.RS_SUCCESS);
         } catch (DmeDnsException dde) {
             Log.e(TAG, Log.getStackTraceString(dde));
             assertTrue("ExecutionException registering client.", false);
@@ -403,10 +407,10 @@ public class EngineCallTest {
         me.setMatchingEngineLocationAllowed(true);
         me.setAllowSwitchIfNoSubscriberInfo(true);
 
-        AppClient.RegisterClientReply reply = null;
+        SessionOuterClass.RegisterClientReply reply = null;
 
         try {
-            AppClient.RegisterClientRequest request = me.createRegisterClientRequest(
+            SessionOuterClass.RegisterClientRequest request = me.createRegisterClientRequest(
                     context,
                     organizationName,
                     applicationName,
@@ -423,7 +427,7 @@ public class EngineCallTest {
                 reply = me.registerClient(request, me.generateDmeHostAddress(), me.getPort(), GRPC_TIMEOUT_MS);
             }
             assertTrue(reply != null);
-            assertTrue(reply.getStatus() == AppClient.ReplyStatus.RS_SUCCESS);
+            assertTrue(reply.getStatus() == Appcommon.ReplyStatus.RS_SUCCESS);
             //assertTrue( !reply.getUniqueId().isEmpty());
             assertTrue( reply.getSessionCookie().length() > 0);
             assertEquals("Sessions must be equal.", reply.getSessionCookie(), me.getSessionCookie());
@@ -451,7 +455,7 @@ public class EngineCallTest {
         // Temporary.
         Log.i(TAG, "registerClientTest reply: " + reply.toString());
         assertEquals(0, reply.getVer());
-        assertEquals(AppClient.ReplyStatus.RS_SUCCESS, reply.getStatus());
+        assertEquals(Appcommon.ReplyStatus.RS_SUCCESS, reply.getStatus());
     }
 
     @Test
@@ -461,10 +465,10 @@ public class EngineCallTest {
         me.setMatchingEngineLocationAllowed(true);
         me.setAllowSwitchIfNoSubscriberInfo(true);
 
-        AppClient.RegisterClientReply reply = null;
+        SessionOuterClass.RegisterClientReply reply = null;
 
         try {
-            AppClient.RegisterClientRequest request = me.createDefaultRegisterClientRequest(context, organizationName)
+            SessionOuterClass.RegisterClientRequest request = me.createDefaultRegisterClientRequest(context, organizationName)
                     .setAppName(applicationName)
                     .setAppVers(appVersion)
                     .build();
@@ -474,7 +478,7 @@ public class EngineCallTest {
                 reply = me.registerClient(request, me.generateDmeHostAddress(), me.getPort(), GRPC_TIMEOUT_MS);
             }
             assertTrue(reply != null);
-            assertTrue(reply.getStatus() == AppClient.ReplyStatus.RS_SUCCESS);
+            assertTrue(reply.getStatus() == Appcommon.ReplyStatus.RS_SUCCESS);
             //assertTrue( !reply.getUniqueId().isEmpty());
             assertTrue( reply.getSessionCookie().length() > 0);
             assertEquals("Sessions must be equal.", reply.getSessionCookie(), me.getSessionCookie());
@@ -502,7 +506,7 @@ public class EngineCallTest {
         // Temporary.
         Log.i(TAG, "registerClientTest reply: " + reply.toString());
         assertEquals(0, reply.getVer());
-        assertEquals(AppClient.ReplyStatus.RS_SUCCESS, reply.getStatus());
+        assertEquals(Appcommon.ReplyStatus.RS_SUCCESS, reply.getStatus());
     }
 
     @Test
@@ -512,11 +516,11 @@ public class EngineCallTest {
         me.setMatchingEngineLocationAllowed(true);
         me.setAllowSwitchIfNoSubscriberInfo(true);
 
-        Future<AppClient.RegisterClientReply> registerReplyFuture;
-        AppClient.RegisterClientReply reply = null;
+        Future<SessionOuterClass.RegisterClientReply> registerReplyFuture;
+        SessionOuterClass.RegisterClientReply reply = null;
 
         try {
-            AppClient.RegisterClientRequest request = me.createDefaultRegisterClientRequest(context, organizationName)
+            SessionOuterClass.RegisterClientRequest request = me.createDefaultRegisterClientRequest(context, organizationName)
                     .setAppName(applicationName)
                     .setAppVers(appVersion)
                     .build();
@@ -548,7 +552,7 @@ public class EngineCallTest {
         // Temporary.
         Log.i(TAG, "registerClientFutureTest() response: " + reply.toString());
         assertEquals(0, reply.getVer());
-        assertEquals(AppClient.ReplyStatus.RS_SUCCESS, reply.getStatus());
+        assertEquals(Appcommon.ReplyStatus.RS_SUCCESS, reply.getStatus());
     }
 
     @Test
@@ -775,7 +779,7 @@ public class EngineCallTest {
         me.setMatchingEngineLocationAllowed(true);
         me.setAllowSwitchIfNoSubscriberInfo(true);
         MeLocation meLoc = new MeLocation(me);
-        AppClient.VerifyLocationReply verifyLocationReply = null;
+        Locverify.VerifyLocationReply verifyLocationReply = null;
 
         try {
             Location location = getTestLocation();
@@ -783,7 +787,7 @@ public class EngineCallTest {
             String carrierName = me.getCarrierName(context);
             registerClient(me);
 
-            AppClient.VerifyLocationRequest verifyLocationRequest = me.createDefaultVerifyLocationRequest(context, location)
+            Locverify.VerifyLocationRequest verifyLocationRequest = me.createDefaultVerifyLocationRequest(context, location)
                     .setCarrierName(carrierName)
                     .build();
 
@@ -819,8 +823,8 @@ public class EngineCallTest {
 
         // Temporary.
         assertEquals(0, verifyLocationReply.getVer());
-        assertEquals(AppClient.VerifyLocationReply.TowerStatus.TOWER_UNKNOWN, verifyLocationReply.getTowerStatus());
-        assertEquals(AppClient.VerifyLocationReply.GPSLocationStatus.LOC_ROAMING_COUNTRY_MATCH, verifyLocationReply.getGpsLocationStatus());
+        assertEquals(Locverify.VerifyLocationReply.TowerStatus.TOWER_UNKNOWN, verifyLocationReply.getTowerStatus());
+        assertEquals(Locverify.VerifyLocationReply.GPSLocationStatus.LOC_ROAMING_COUNTRY_MATCH, verifyLocationReply.getGpsLocationStatus());
     }
 
     @Test
@@ -830,15 +834,15 @@ public class EngineCallTest {
         MatchingEngine me = new MatchingEngine(context);
         me.setMatchingEngineLocationAllowed(true);
         me.setAllowSwitchIfNoSubscriberInfo(true);
-        AppClient.VerifyLocationReply verifyLocationReply = null;
-        Future<AppClient.VerifyLocationReply> verifyLocationReplyFuture = null;
+        Locverify.VerifyLocationReply verifyLocationReply = null;
+        Future<Locverify.VerifyLocationReply> verifyLocationReplyFuture = null;
 
         try {
             Location location = getTestLocation();
 
             String carrierName = me.getCarrierName(context);
             registerClient(me);
-            AppClient.VerifyLocationRequest verifyLocationRequest = me.createDefaultVerifyLocationRequest(context, location)
+            Locverify.VerifyLocationRequest verifyLocationRequest = me.createDefaultVerifyLocationRequest(context, location)
                     .setCarrierName(carrierName)
                     .build();
             if (useHostOverride) {
@@ -864,8 +868,8 @@ public class EngineCallTest {
 
         // Temporary.
         assertEquals(0, verifyLocationReply.getVer());
-        assertEquals(AppClient.VerifyLocationReply.TowerStatus.TOWER_UNKNOWN, verifyLocationReply.getTowerStatus());
-        assertEquals(AppClient.VerifyLocationReply.GPSLocationStatus.LOC_ROAMING_COUNTRY_MATCH, verifyLocationReply.getGpsLocationStatus());
+        assertEquals(Locverify.VerifyLocationReply.TowerStatus.TOWER_UNKNOWN, verifyLocationReply.getTowerStatus());
+        assertEquals(Locverify.VerifyLocationReply.GPSLocationStatus.LOC_ROAMING_COUNTRY_MATCH, verifyLocationReply.getGpsLocationStatus());
     }
 
     /**
@@ -879,13 +883,13 @@ public class EngineCallTest {
         me.setMatchingEngineLocationAllowed(true);
         me.setAllowSwitchIfNoSubscriberInfo(true);
 
-        AppClient.VerifyLocationReply verifyLocationReply = null;
+        Locverify.VerifyLocationReply verifyLocationReply = null;
         try {
             Location location = getTestLocation();
 
             String carrierName = me.getCarrierName(context);
             registerClient(me);
-            AppClient.VerifyLocationRequest verifyLocationRequest = me.createDefaultVerifyLocationRequest(context, location)
+            Locverify.VerifyLocationRequest verifyLocationRequest = me.createDefaultVerifyLocationRequest(context, location)
                     .setCarrierName(carrierName)
                     .build();
             if (useHostOverride) {
@@ -913,8 +917,8 @@ public class EngineCallTest {
 
         // Temporary.
         assertEquals(0, verifyLocationReply.getVer());
-        assertEquals(AppClient.VerifyLocationReply.TowerStatus.TOWER_UNKNOWN, verifyLocationReply.getTowerStatus());
-        assertEquals(AppClient.VerifyLocationReply.GPSLocationStatus.LOC_ROAMING_COUNTRY_MATCH, verifyLocationReply.getGpsLocationStatus()); // Based on test data.
+        assertEquals(Locverify.VerifyLocationReply.TowerStatus.TOWER_UNKNOWN, verifyLocationReply.getTowerStatus());
+        assertEquals(Locverify.VerifyLocationReply.GPSLocationStatus.LOC_ROAMING_COUNTRY_MATCH, verifyLocationReply.getGpsLocationStatus()); // Based on test data.
 
     }
 
@@ -926,7 +930,7 @@ public class EngineCallTest {
         me.setMatchingEngineLocationAllowed(true);
         me.setAllowSwitchIfNoSubscriberInfo(true);
 
-        AppClient.DynamicLocGroupReply dynamicLocGroupReply = null;
+        DynamicLocationGroup.DynamicLocGroupReply dynamicLocGroupReply = null;
         Location loc = getTestLocation();
 
         String carrierName = me.getCarrierName(context);
@@ -935,9 +939,9 @@ public class EngineCallTest {
 
             // FIXME: Need groupId source.
             long groupId = 1001L;
-            AppClient.DynamicLocGroupRequest dynamicLocGroupRequest = me.createDefaultDynamicLocGroupRequest(
+            DynamicLocationGroup.DynamicLocGroupRequest dynamicLocGroupRequest = me.createDefaultDynamicLocGroupRequest(
                     context,
-                    AppClient.DynamicLocGroupRequest.DlgCommType.DLG_SECURE)
+                    DynamicLocationGroup.DynamicLocGroupRequest.DlgCommType.DLG_SECURE)
                     .build();
 
             if (useHostOverride) {
@@ -945,7 +949,7 @@ public class EngineCallTest {
             } else {
                 dynamicLocGroupReply = me.addUserToGroup(dynamicLocGroupRequest, GRPC_TIMEOUT_MS);
             }
-            assertTrue("DynamicLocation Group Add should return: ME_SUCCESS", dynamicLocGroupReply.getStatus() == AppClient.ReplyStatus.RS_SUCCESS);
+            assertTrue("DynamicLocation Group Add should return: ME_SUCCESS", dynamicLocGroupReply.getStatus() == Appcommon.ReplyStatus.RS_SUCCESS);
             assertTrue("Group cookie result.", dynamicLocGroupReply.getGroupCookie().equals("")); // FIXME: This GroupCookie should have a value.
 
         } catch (DmeDnsException dde) {
@@ -976,7 +980,7 @@ public class EngineCallTest {
         me.setMatchingEngineLocationAllowed(true);
         me.setAllowSwitchIfNoSubscriberInfo(true);
 
-        AppClient.DynamicLocGroupReply dynamicLocGroupReply = null;
+        DynamicLocationGroup.DynamicLocGroupReply dynamicLocGroupReply = null;
 
         Location loc = getTestLocation();
         String carrierName = me.getCarrierName(context);
@@ -985,19 +989,19 @@ public class EngineCallTest {
 
             // FIXME: Need groupId source.
             long groupId = 1001L;
-            AppClient.DynamicLocGroupRequest dynamicLocGroupRequest = me.createDefaultDynamicLocGroupRequest(
+            DynamicLocationGroup.DynamicLocGroupRequest dynamicLocGroupRequest = me.createDefaultDynamicLocGroupRequest(
                     context,
-                    AppClient.DynamicLocGroupRequest.DlgCommType.DLG_SECURE)
+                    DynamicLocationGroup.DynamicLocGroupRequest.DlgCommType.DLG_SECURE)
                     .build();
 
-            Future<AppClient.DynamicLocGroupReply> responseFuture;
+            Future<DynamicLocationGroup.DynamicLocGroupReply> responseFuture;
             if (useHostOverride) {
                 responseFuture = me.addUserToGroupFuture(dynamicLocGroupRequest, hostOverride, portOverride, GRPC_TIMEOUT_MS);
             } else {
                 responseFuture = me.addUserToGroupFuture(dynamicLocGroupRequest, GRPC_TIMEOUT_MS);
             }
             dynamicLocGroupReply = responseFuture.get();
-            assertTrue("DynamicLocation Group Add should return: ME_SUCCESS", dynamicLocGroupReply.getStatus() == AppClient.ReplyStatus.RS_SUCCESS);
+            assertTrue("DynamicLocation Group Add should return: ME_SUCCESS", dynamicLocGroupReply.getStatus() == Appcommon.ReplyStatus.RS_SUCCESS);
             assertTrue("Group cookie result.", dynamicLocGroupReply.getGroupCookie().equals("")); // FIXME: This GroupCookie should have a value.
         } catch (DmeDnsException dde) {
             Log.e(TAG, Log.getStackTraceString(dde));
@@ -1135,7 +1139,7 @@ public class EngineCallTest {
 
         Location location = getTestLocation();
 
-        ChannelIterator<AppClient.QosPositionKpiReply> responseIterator = null;
+        ChannelIterator<QosPositionOuterClass.QosPositionKpiReply> responseIterator = null;
         try {
             registerClient(me);
 
@@ -1143,10 +1147,10 @@ public class EngineCallTest {
             double increment = 0.1;
             double direction = 45d;
 
-            ArrayList<AppClient.QosPosition> kpiRequests = MockUtils.createQosPositionArray(location, direction, totalDistanceKm, increment);
+            ArrayList<QosPositionOuterClass.QosPosition> kpiRequests = MockUtils.createQosPositionArray(location, direction, totalDistanceKm, increment);
 
             //! [createdefqosexample]
-            AppClient.QosPositionRequest request = me.createDefaultQosPositionRequest(kpiRequests, 0, null).build();
+            QosPositionOuterClass.QosPositionRequest request = me.createDefaultQosPositionRequest(kpiRequests, 0, null).build();
             //! [createdefqosexample]
             assertFalse("SessionCookie must not be empty.", request.getSessionCookie().isEmpty());
 
@@ -1162,7 +1166,7 @@ public class EngineCallTest {
             // A stream of QosPositionKpiReply(s), with a non-stream block of responses.
             long total = 0;
             while (responseIterator.hasNext()) {
-                AppClient.QosPositionKpiReply aR = responseIterator.next();
+                QosPositionOuterClass.QosPositionKpiReply aR = responseIterator.next();
                 for (int i = 0; i < aR.getPositionResultsCount(); i++) {
                     System.out.println(aR.getPositionResults(i));
                 }
@@ -1209,13 +1213,13 @@ public class EngineCallTest {
             double increment = 0.1;
             double direction = 45d;
 
-            ArrayList<AppClient.QosPosition> kpiRequests = MockUtils.createQosPositionArray(location, direction, totalDistanceKm, increment);
+            ArrayList<QosPositionOuterClass.QosPosition> kpiRequests = MockUtils.createQosPositionArray(location, direction, totalDistanceKm, increment);
 
-            AppClient.BandSelection bandSelection = AppClient.BandSelection.newBuilder().build();
-            AppClient.QosPositionRequest request = me.createDefaultQosPositionRequest(kpiRequests, 0, bandSelection).build();
+            QosPositionOuterClass.BandSelection bandSelection = QosPositionOuterClass.BandSelection.newBuilder().build();
+            QosPositionOuterClass.QosPositionRequest request = me.createDefaultQosPositionRequest(kpiRequests, 0, bandSelection).build();
             assertFalse("SessionCookie must not be empty.", request.getSessionCookie().isEmpty());
 
-            Future<ChannelIterator<AppClient.QosPositionKpiReply>> replyFuture = null;
+            Future<ChannelIterator<QosPositionOuterClass.QosPositionKpiReply>> replyFuture = null;
             if (useHostOverride) {
                 replyFuture = me.getQosPositionKpiFuture(request, hostOverride, portOverride, GRPC_TIMEOUT_MS);
             } else {
@@ -1223,10 +1227,10 @@ public class EngineCallTest {
             }
             // A stream of QosPositionKpiReply(s), with a non-stream block of responses.
             // Wait for value with get().
-            ChannelIterator<AppClient.QosPositionKpiReply> responseIterator = replyFuture.get();
+            ChannelIterator<QosPositionOuterClass.QosPositionKpiReply> responseIterator = replyFuture.get();
             long total = 0;
             while (responseIterator.hasNext()) {
-                AppClient.QosPositionKpiReply aR = responseIterator.next();
+                QosPositionOuterClass.QosPositionKpiReply aR = responseIterator.next();
                 for (int i = 0; i < aR.getPositionResultsCount(); i++) {
                     System.out.println(aR.getPositionResults(i));
                 }
@@ -1981,7 +1985,7 @@ public class EngineCallTest {
 
         Location loc = MockUtils.createLocation("findCloudletTest", 122.3321, 47.6062);
         try {
-            AppClient.VerifyLocationRequest.Builder requestBuilder = me.createDefaultVerifyLocationRequest(context, loc);
+            Locverify.VerifyLocationRequest.Builder requestBuilder = me.createDefaultVerifyLocationRequest(context, loc);
             assertFalse("We should not be here, expected an user error and illegal engine state.", true);
         } catch (IllegalArgumentException iae) {
             Log.i(TAG, Log.getStackTraceString(iae));
@@ -2016,11 +2020,11 @@ public class EngineCallTest {
         me.setAllowSwitchIfNoSubscriberInfo(true);
 
         try {
-            AppClient.QosPosition qos = AppClient.QosPosition.newBuilder().build();
-            List<AppClient.QosPosition> list = new ArrayList<>();
+            QosPositionOuterClass.QosPosition qos = QosPositionOuterClass.QosPosition.newBuilder().build();
+            List<QosPositionOuterClass.QosPosition> list = new ArrayList<>();
             list.add(qos);
-            AppClient.BandSelection bandSelection = AppClient.BandSelection.newBuilder().build();
-            AppClient.QosPositionRequest.Builder requestBuilder = me.createDefaultQosPositionRequest(list, 0, bandSelection);
+            QosPositionOuterClass.BandSelection bandSelection = QosPositionOuterClass.BandSelection.newBuilder().build();
+            QosPositionOuterClass.QosPositionRequest.Builder requestBuilder = me.createDefaultQosPositionRequest(list, 0, bandSelection);
             assertFalse("We should not be here, expected an user error and illegal engine state.", true);
         } catch (IllegalArgumentException iae) {
             Log.i(TAG, Log.getStackTraceString(iae));

--- a/EmptyMatchEngineApp/matchingengine/src/androidTest/java/com/mobiledgex/matchingengine/MockUtils.java
+++ b/EmptyMatchEngineApp/matchingengine/src/androidTest/java/com/mobiledgex/matchingengine/MockUtils.java
@@ -28,7 +28,7 @@ import java.util.concurrent.ExecutionException;
 
 import distributed_match_engine.AppClient;
 import distributed_match_engine.LocOuterClass;
-import distributed_match_engine.AppClient.QosPosition;
+import distributed_match_engine.QosPositionOuterClass.QosPosition;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -69,7 +69,7 @@ public class MockUtils {
                     .setLatitude(latitude)
                 .build();
 
-            QosPosition np = AppClient.QosPosition.newBuilder()
+            QosPosition np = QosPosition.newBuilder()
                     .setPositionid(id++)
                     .setGpsLocation(loc)
                     .build();

--- a/EmptyMatchEngineApp/matchingengine/src/androidTest/java/com/mobiledgex/matchingengine/QosPrioritySessionTest.java
+++ b/EmptyMatchEngineApp/matchingengine/src/androidTest/java/com/mobiledgex/matchingengine/QosPrioritySessionTest.java
@@ -41,6 +41,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
 import distributed_match_engine.AppClient;
+import distributed_match_engine.Appcommon;
+import distributed_match_engine.Qos;
+import distributed_match_engine.SessionOuterClass;
 import io.grpc.StatusRuntimeException;
 
 @RunWith(AndroidJUnit4.class)
@@ -112,12 +115,12 @@ public class QosPrioritySessionTest {
   public void registerClient(MatchingEngine me) {
     Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
-    AppClient.RegisterClientReply registerReply;
-    AppClient.RegisterClientRequest registerClientRequest;
+    SessionOuterClass.RegisterClientReply registerReply;
+    SessionOuterClass.RegisterClientRequest registerClientRequest;
 
     try {
       // The app version will be null, but we can build from scratch for test
-      AppClient.RegisterClientRequest.Builder regRequestBuilder = AppClient.RegisterClientRequest.newBuilder()
+      SessionOuterClass.RegisterClientRequest.Builder regRequestBuilder = SessionOuterClass.RegisterClientRequest.newBuilder()
               .setOrgName(organizationName)
               .setAppName(applicationName)
               .setAppVers(appVersion);
@@ -134,7 +137,7 @@ public class QosPrioritySessionTest {
       }
       assertEquals("Response SessionCookie should equal MatchingEngine SessionCookie",
               registerReply.getSessionCookie(), me.getSessionCookie());
-      assertTrue(registerReply.getStatus() == AppClient.ReplyStatus.RS_SUCCESS);
+      assertTrue(registerReply.getStatus() == Appcommon.ReplyStatus.RS_SUCCESS);
     } catch (DmeDnsException dde) {
       Log.e(TAG, Log.getStackTraceString(dde));
       assertTrue("ExecutionException registering client.", false);
@@ -166,16 +169,16 @@ public class QosPrioritySessionTest {
       String protocol = "TCP";
       String profile = "QOS_LOW_LATENCY";
 
-      AppClient.QosPrioritySessionCreateRequest.Builder builder = me.createDefaultQosPrioritySessionCreateRequest(context);
+      Qos.QosPrioritySessionCreateRequest.Builder builder = me.createDefaultQosPrioritySessionCreateRequest(context);
       builder.setPortApplicationServer("8008");
       builder.setIpUserEquipment(ipUserEquipment);
       builder.setIpApplicationServer(ipApplicationServer);
-      builder.setProtocolIn(AppClient.QosSessionProtocol.valueOf(protocol));
-      builder.setProfile(AppClient.QosSessionProfile.valueOf(profile));
+      builder.setProtocolIn(Qos.QosSessionProtocol.valueOf(protocol));
+      builder.setProfile(Qos.QosSessionProfile.valueOf(profile));
       builder.setSessionDuration(duration);
 
-      AppClient.QosPrioritySessionCreateRequest qosPrioritySessionCreateRequest;
-      Future<AppClient.QosPrioritySessionReply> qosPrioritySessionReplyFuture;
+      Qos.QosPrioritySessionCreateRequest qosPrioritySessionCreateRequest;
+      Future<Qos.QosPrioritySessionReply> qosPrioritySessionReplyFuture;
 
       qosPrioritySessionCreateRequest = builder.build();
 
@@ -188,7 +191,7 @@ public class QosPrioritySessionTest {
         qosPrioritySessionReplyFuture = me.qosPrioritySessionCreateFuture(qosPrioritySessionCreateRequest, GRPC_TIMEOUT_MS);
         //! [qosprioritysessioncreatefutureexample]
       }
-      AppClient.QosPrioritySessionReply qosPrioritySessionReply = qosPrioritySessionReplyFuture.get();
+      Qos.QosPrioritySessionReply qosPrioritySessionReply = qosPrioritySessionReplyFuture.get();
       Log.i(TAG, "mQosPrioritySessionReply.getSessionId()="+ qosPrioritySessionReply.getSessionId()+" mQosPrioritySessionReply.getHttpStatus()="+ qosPrioritySessionReply.getHttpStatus());
 
       assert (qosPrioritySessionReply != null);
@@ -229,19 +232,19 @@ public class QosPrioritySessionTest {
       String protocol = "TCP";
       String profile = "QOS_LOW_LATENCY";
 
-      AppClient.QosPrioritySessionCreateRequest.Builder builder = me.createDefaultQosPrioritySessionCreateRequest(context);
+      Qos.QosPrioritySessionCreateRequest.Builder builder = me.createDefaultQosPrioritySessionCreateRequest(context);
       builder.setPortApplicationServer(""+port);
       builder.setIpUserEquipment(ipUserEquipment);
       builder.setIpApplicationServer(ipApplicationServer);
-      builder.setProtocolIn(AppClient.QosSessionProtocol.valueOf(protocol));
-      builder.setProfile(AppClient.QosSessionProfile.valueOf(profile));
+      builder.setProtocolIn(Qos.QosSessionProtocol.valueOf(protocol));
+      builder.setProfile(Qos.QosSessionProfile.valueOf(profile));
       builder.setSessionDuration(duration);
 
-      AppClient.QosPrioritySessionCreateRequest qosPrioritySessionCreateRequest;
+      Qos.QosPrioritySessionCreateRequest qosPrioritySessionCreateRequest;
 
       qosPrioritySessionCreateRequest = builder.build();
 
-      AppClient.QosPrioritySessionReply qosPrioritySessionReply;
+      Qos.QosPrioritySessionReply qosPrioritySessionReply;
 
       if (useHostOverride) {
         //! [qosprioritysessioncreatefutureoverrideexample]
@@ -283,7 +286,7 @@ public class QosPrioritySessionTest {
     me.setSSLEnabled(false);
 
     try {
-      AppClient.QosPrioritySessionCreateRequest.Builder builder = me.createDefaultQosPrioritySessionCreateRequest(context);
+      Qos.QosPrioritySessionCreateRequest.Builder builder = me.createDefaultQosPrioritySessionCreateRequest(context);
     } catch (IllegalArgumentException iae) {
       Log.e(TAG, Log.getStackTraceString(iae));
       assertEquals(iae.getMessage(), ("An unexpired RegisterClient sessionCookie is required."));
@@ -308,12 +311,12 @@ public class QosPrioritySessionTest {
       String protocol = "TCP";
       String profile = "QOS_LOW_LATENCY";
 
-      AppClient.QosPrioritySessionDeleteRequest.Builder builder = me.createDefaultQosPrioritySessionDeleteRequest(context);
-      builder.setProfile(AppClient.QosSessionProfile.valueOf(profile));
+      Qos.QosPrioritySessionDeleteRequest.Builder builder = me.createDefaultQosPrioritySessionDeleteRequest(context);
+      builder.setProfile(Qos.QosSessionProfile.valueOf(profile));
       builder.setSessionId(qosSesId);
 
-      AppClient.QosPrioritySessionDeleteRequest qosPrioritySessionDeleteRequest;
-      Future<AppClient.QosPrioritySessionDeleteReply> qosPrioritySessionDeleteReplyFuture;
+      Qos.QosPrioritySessionDeleteRequest qosPrioritySessionDeleteRequest;
+      Future<Qos.QosPrioritySessionDeleteReply> qosPrioritySessionDeleteReplyFuture;
 
       qosPrioritySessionDeleteRequest = builder.build();
 
@@ -326,7 +329,7 @@ public class QosPrioritySessionTest {
         qosPrioritySessionDeleteReplyFuture = me.qosPrioritySessionDeleteFuture(qosPrioritySessionDeleteRequest, GRPC_TIMEOUT_MS);
         //! [qosprioritysessiondeletefutureexample]
       }
-      AppClient.QosPrioritySessionDeleteReply qosPrioritySessionDeleteReply = qosPrioritySessionDeleteReplyFuture.get();
+      Qos.QosPrioritySessionDeleteReply qosPrioritySessionDeleteReply = qosPrioritySessionDeleteReplyFuture.get();
       Log.i(TAG, "qosPrioritySessionDeleteReply.getStatus()="+ qosPrioritySessionDeleteReply.getStatus());
 
       assert (qosPrioritySessionDeleteReply != null);
@@ -360,12 +363,12 @@ public class QosPrioritySessionTest {
       String protocol = "TCP";
       String profile = "QOS_LOW_LATENCY";
 
-      AppClient.QosPrioritySessionDeleteRequest.Builder builder = me.createDefaultQosPrioritySessionDeleteRequest(context);
-      builder.setProfile(AppClient.QosSessionProfile.valueOf(profile));
+      Qos.QosPrioritySessionDeleteRequest.Builder builder = me.createDefaultQosPrioritySessionDeleteRequest(context);
+      builder.setProfile(Qos.QosSessionProfile.valueOf(profile));
       builder.setSessionId(qosSesId);
-      AppClient.QosPrioritySessionDeleteRequest qosPrioritySessionDeleteRequest = builder.build();
+      Qos.QosPrioritySessionDeleteRequest qosPrioritySessionDeleteRequest = builder.build();
 
-      AppClient.QosPrioritySessionDeleteReply qosPrioritySessionDeleteReply;
+      Qos.QosPrioritySessionDeleteReply qosPrioritySessionDeleteReply;
 
       if (useHostOverride) {
         //! [qosprioritysessiondeletefutureoverrideexample]
@@ -409,12 +412,12 @@ public class QosPrioritySessionTest {
       String protocol = "TCP";
       String profile = "QOS_LOW_LATENCY";
 
-      AppClient.QosPrioritySessionDeleteRequest.Builder builder = me.createDefaultQosPrioritySessionDeleteRequest(context);
-      builder.setProfile(AppClient.QosSessionProfile.valueOf(profile));
+      Qos.QosPrioritySessionDeleteRequest.Builder builder = me.createDefaultQosPrioritySessionDeleteRequest(context);
+      builder.setProfile(Qos.QosSessionProfile.valueOf(profile));
       builder.setSessionId("this-is-a-bad-session-id");
-      AppClient.QosPrioritySessionDeleteRequest qosPrioritySessionDeleteRequest = builder.build();
+      Qos.QosPrioritySessionDeleteRequest qosPrioritySessionDeleteRequest = builder.build();
 
-      AppClient.QosPrioritySessionDeleteReply qosPrioritySessionDeleteReply;
+      Qos.QosPrioritySessionDeleteReply qosPrioritySessionDeleteReply;
 
       if (useHostOverride) {
         //! [qosprioritysessiondeletefutureoverrideexample]

--- a/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/AddUserToGroup.java
+++ b/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/AddUserToGroup.java
@@ -24,9 +24,9 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
-import distributed_match_engine.AppClient.DynamicLocGroupRequest;
-import distributed_match_engine.AppClient.DynamicLocGroupReply;
-import distributed_match_engine.MatchEngineApiGrpc;
+import distributed_match_engine.DynamicLocGroupApiGrpc;
+import distributed_match_engine.DynamicLocationGroup.DynamicLocGroupRequest;
+import distributed_match_engine.DynamicLocationGroup.DynamicLocGroupReply;
 import io.grpc.ManagedChannel;
 import io.grpc.StatusRuntimeException;
 
@@ -82,7 +82,7 @@ class AddUserToGroup implements Callable {
             Network network = nm.getCellularNetworkOrWifiBlocking(false, mMatchingEngine.getMccMnc(mMatchingEngine.mContext));
 
             channel = mMatchingEngine.channelPicker(mHost, mPort, network);
-            MatchEngineApiGrpc.MatchEngineApiBlockingStub stub = MatchEngineApiGrpc.newBlockingStub(channel);
+            DynamicLocGroupApiGrpc.DynamicLocGroupApiBlockingStub stub = DynamicLocGroupApiGrpc.newBlockingStub(channel);
 
             reply = stub.withDeadlineAfter(mTimeoutInMilliseconds, TimeUnit.MILLISECONDS)
                     .addUserToGroup(mRequest);

--- a/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
+++ b/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
@@ -59,27 +59,32 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
 import distributed_match_engine.AppClient;
-import distributed_match_engine.AppClient.RegisterClientRequest;
-import distributed_match_engine.AppClient.RegisterClientReply;
-import distributed_match_engine.AppClient.VerifyLocationRequest;
-import distributed_match_engine.AppClient.VerifyLocationReply;
+import distributed_match_engine.DynamicLocationGroup;
+import distributed_match_engine.Locverify;
+import distributed_match_engine.Qos;
+import distributed_match_engine.QosPositionOuterClass;
+import distributed_match_engine.SessionOuterClass;
+import distributed_match_engine.SessionOuterClass.RegisterClientRequest;
+import distributed_match_engine.SessionOuterClass.RegisterClientReply;
+import distributed_match_engine.Locverify.VerifyLocationRequest;
+import distributed_match_engine.Locverify.VerifyLocationReply;
 import distributed_match_engine.AppClient.FindCloudletRequest;
 import distributed_match_engine.AppClient.FindCloudletReply;
-import distributed_match_engine.AppClient.GetLocationRequest;
-import distributed_match_engine.AppClient.GetLocationReply;
+import distributed_match_engine.Locverify.GetLocationRequest;
+import distributed_match_engine.Locverify.GetLocationReply;
 import distributed_match_engine.AppClient.AppInstListRequest;
 import distributed_match_engine.AppClient.AppInstListReply;
-import distributed_match_engine.AppClient.QosPositionRequest;
-import distributed_match_engine.AppClient.QosPositionKpiReply;
-import distributed_match_engine.AppClient.QosPosition;
-import distributed_match_engine.AppClient.QosPrioritySessionCreateRequest;
-import distributed_match_engine.AppClient.QosPrioritySessionReply;
-import distributed_match_engine.AppClient.QosPrioritySessionDeleteRequest;
-import distributed_match_engine.AppClient.QosPrioritySessionDeleteReply;
-import distributed_match_engine.AppClient.BandSelection;
+import distributed_match_engine.QosPositionOuterClass.QosPositionRequest;
+import distributed_match_engine.QosPositionOuterClass.QosPositionKpiReply;
+import distributed_match_engine.QosPositionOuterClass.QosPosition;
+import distributed_match_engine.Qos.QosPrioritySessionCreateRequest;
+import distributed_match_engine.Qos.QosPrioritySessionReply;
+import distributed_match_engine.Qos.QosPrioritySessionDeleteRequest;
+import distributed_match_engine.Qos.QosPrioritySessionDeleteReply;
+import distributed_match_engine.QosPositionOuterClass.BandSelection;
 
-import distributed_match_engine.AppClient.DynamicLocGroupRequest;
-import distributed_match_engine.AppClient.DynamicLocGroupReply;
+import distributed_match_engine.DynamicLocationGroup.DynamicLocGroupRequest;
+import distributed_match_engine.DynamicLocationGroup.DynamicLocGroupReply;
 
 import distributed_match_engine.Appcommon;
 import distributed_match_engine.LocOuterClass;
@@ -691,14 +696,14 @@ public class MatchingEngine {
         return mRegisterClientRequest;
     }
 
-    synchronized void setLastRegisterClientRequest(AppClient.RegisterClientRequest registerRequest) {
+    synchronized void setLastRegisterClientRequest(SessionOuterClass.RegisterClientRequest registerRequest) {
         mRegisterClientRequest = registerRequest;
     }
 
     synchronized RegisterClientReply getMatchingEngineStatus() {
         return mRegisterClientReply;
     }
-    synchronized void setMatchEngineStatus(AppClient.RegisterClientReply status) {
+    synchronized void setMatchEngineStatus(SessionOuterClass.RegisterClientReply status) {
         mRegisterClientReply = status;
     }
 
@@ -707,7 +712,7 @@ public class MatchingEngine {
         mMatchEngineLocation = locationReply.getNetworkLocation();
     }
 
-    synchronized void setVerifyLocationReply(AppClient.VerifyLocationReply locationVerify) {
+    synchronized void setVerifyLocationReply(Locverify.VerifyLocationReply locationVerify) {
         mVerifyLocationReply = locationVerify;
     }
 
@@ -1063,7 +1068,7 @@ public class MatchingEngine {
             versionName = "";
         }
 
-        RegisterClientRequest.Builder builder = AppClient.RegisterClientRequest.newBuilder()
+        RegisterClientRequest.Builder builder = SessionOuterClass.RegisterClientRequest.newBuilder()
                 .setOrgName(organizationName);
 
         if (appName != null) {
@@ -1118,7 +1123,7 @@ public class MatchingEngine {
 
         versionName = (appVersion == null || appVersion.isEmpty()) ? getAppVersion(context) : appVersion;
 
-        RegisterClientRequest.Builder builder = AppClient.RegisterClientRequest.newBuilder()
+        RegisterClientRequest.Builder builder = SessionOuterClass.RegisterClientRequest.newBuilder()
                 .setOrgName((organizationName == null) ? "" : organizationName)
                 .setAppName(appName)
                 .setAppVers(versionName)
@@ -1167,7 +1172,7 @@ public class MatchingEngine {
         String carrierName = getCarrierName(context);
         Loc aLoc = androidLocToMeLoc(location);
 
-        VerifyLocationRequest.Builder builder = AppClient.VerifyLocationRequest.newBuilder()
+        VerifyLocationRequest.Builder builder = Locverify.VerifyLocationRequest.newBuilder()
                 .setSessionCookie(mSessionCookie)
                 .setCarrierName(carrierName)
                 .setGpsLocation(aLoc); // Latest token is unknown until retrieved.
@@ -1212,7 +1217,7 @@ public class MatchingEngine {
      * @private
      * \ingroup functions_dmeapis
      */
-    public AppClient.GetLocationRequest.Builder createDefaultGetLocationRequest(Context context) {
+    public Locverify.GetLocationRequest.Builder createDefaultGetLocationRequest(Context context) {
         if (!mMatchingEngineLocationAllowed) {
             Log.e(TAG, "Location Permission required to Create DefaultGetLocationRequest. Consider using com.mobiledgex.matchingengine.util.RequestPermissions and then calling MatchingEngine.setMatchingEngineLocationAllowed(true).");
             return null;
@@ -1265,7 +1270,7 @@ public class MatchingEngine {
      * \section createdefappinstexample Example
      * \snippet EngineCallTest.java createdefappinstexample
      */
-    public AppClient.QosPrioritySessionCreateRequest.Builder createDefaultQosPrioritySessionCreateRequest(Context context) {
+    public Qos.QosPrioritySessionCreateRequest.Builder createDefaultQosPrioritySessionCreateRequest(Context context) {
         if (!mMatchingEngineLocationAllowed) {
             Log.e(TAG, "Location Permission required to Create DefaultQosPrioritySessionCreateRequest. Consider using com.mobiledgex.matchingengine.util.RequestPermissions and then calling MatchingEngine.setMatchingEngineLocationAllowed(true).");
             return null;
@@ -1288,7 +1293,7 @@ public class MatchingEngine {
      * \section createdefappinstexample Example
      * \snippet EngineCallTest.java createdefappinstexample
      */
-    public AppClient.QosPrioritySessionDeleteRequest.Builder createDefaultQosPrioritySessionDeleteRequest(Context context) {
+    public Qos.QosPrioritySessionDeleteRequest.Builder createDefaultQosPrioritySessionDeleteRequest(Context context) {
         if (!mMatchingEngineLocationAllowed) {
             Log.e(TAG, "Location Permission required to Delete DefaultQosPrioritySessionDeleteRequest. Consider using com.mobiledgex.matchingengine.util.RequestPermissions and then calling MatchingEngine.setMatchingEngineLocationAllowed(true).");
             return null;
@@ -1306,7 +1311,7 @@ public class MatchingEngine {
      * @private
      * \ingroup functions_dmeapis
      */
-    public AppClient.DynamicLocGroupRequest.Builder createDefaultDynamicLocGroupRequest(Context context, DynamicLocGroupRequest.DlgCommType commType) {
+    public DynamicLocationGroup.DynamicLocGroupRequest.Builder createDefaultDynamicLocGroupRequest(Context context, DynamicLocGroupRequest.DlgCommType commType) {
         if (!mMatchingEngineLocationAllowed) {
             Log.e(TAG, "Location Permission required to Create DefaultDynamicLocGroupRequest. Consider using com.mobiledgex.matchingengine.util.RequestPermissions and then calling MatchingEngine.setMatchingEngineLocationAllowed(true).");
             return null;
@@ -1333,7 +1338,7 @@ public class MatchingEngine {
      * \section createdefqosexample Example
      * \snippet EngineCallTest.java createdefqosexample
      */
-    public AppClient.QosPositionRequest.Builder createDefaultQosPositionRequest(List<QosPosition> requests, int lte_category, BandSelection band_selection) {
+    public QosPositionOuterClass.QosPositionRequest.Builder createDefaultQosPositionRequest(List<QosPosition> requests, int lte_category, BandSelection band_selection) {
 
         if (!mMatchingEngineLocationAllowed) {
             Log.e(TAG, "Location Permission required to Create DefaultQosPositionRequest. Consider using com.mobiledgex.matchingengine.util.RequestPermissions and then calling MatchingEngine.setMatchingEngineLocationAllowed(true).");
@@ -1414,7 +1419,7 @@ public class MatchingEngine {
         RegisterClient registerClient = new RegisterClient(this); // Instanced, so just add host, port as field.
         registerClient.setRequest(request, host, port, timeoutInMilliseconds);
 
-        Log.i(TAG, "DME host is: " + host);
+        Log.i(TAG, "DME host is: " + host + ":" + port);
         return registerClient.call();
     }
 

--- a/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/QosPositionKpi.java
+++ b/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/QosPositionKpi.java
@@ -25,18 +25,18 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
+import distributed_match_engine.QosPositionKpiGrpc;
 import io.grpc.ManagedChannel;
 import io.grpc.StatusRuntimeException;
 
-import distributed_match_engine.MatchEngineApiGrpc;
-import distributed_match_engine.AppClient;
-import distributed_match_engine.AppClient.QosPositionRequest;
-import distributed_match_engine.AppClient.QosPositionKpiReply;
+import distributed_match_engine.QosPositionOuterClass;
+import distributed_match_engine.QosPositionOuterClass.QosPositionRequest;
+import distributed_match_engine.QosPositionOuterClass.QosPositionKpiReply;
 
 public class QosPositionKpi implements Callable {
     public static final String TAG = "QueryQosKpi";
     private MatchingEngine mMatchingEngine;
-    private AppClient.QosPositionRequest mQosPositionKpiRequest;
+    private QosPositionOuterClass.QosPositionRequest mQosPositionKpiRequest;
     private String mHost;
     private int mPort;
     private long mTimeoutInMilliseconds;
@@ -101,7 +101,7 @@ public class QosPositionKpi implements Callable {
             Network network = nm.getCellularNetworkOrWifiBlocking(false, mMatchingEngine.getMccMnc(mMatchingEngine.mContext));
 
             channel = mMatchingEngine.channelPicker(mHost, mPort, network);
-            MatchEngineApiGrpc.MatchEngineApiBlockingStub stub = MatchEngineApiGrpc.newBlockingStub(channel);
+            QosPositionKpiGrpc.QosPositionKpiBlockingStub stub = QosPositionKpiGrpc.newBlockingStub(channel);
 
             response = stub.withDeadlineAfter(mTimeoutInMilliseconds, TimeUnit.MILLISECONDS)
                     .getQosPositionKpi(mQosPositionKpiRequest);

--- a/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/QosPrioritySessionCreate.java
+++ b/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/QosPrioritySessionCreate.java
@@ -24,12 +24,11 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
-import distributed_match_engine.AppClient;
-import distributed_match_engine.AppClient.AppInstListReply;
-import distributed_match_engine.AppClient.AppInstListRequest;
-import distributed_match_engine.AppClient.QosPrioritySessionCreateRequest;
-import distributed_match_engine.AppClient.QosPrioritySessionReply;
+import distributed_match_engine.DynamicLocGroupApiGrpc;
+import distributed_match_engine.Qos.QosPrioritySessionCreateRequest;
+import distributed_match_engine.Qos.QosPrioritySessionReply;
 import distributed_match_engine.MatchEngineApiGrpc;
+import distributed_match_engine.QualityOfServiceGrpc;
 import io.grpc.ManagedChannel;
 import io.grpc.StatusRuntimeException;
 
@@ -86,7 +85,7 @@ public class QosPrioritySessionCreate implements Callable {
             Network network = nm.getCellularNetworkOrWifiBlocking(false, mMatchingEngine.getMccMnc(mMatchingEngine.mContext));
 
             channel = mMatchingEngine.channelPicker(mHost, mPort, network);
-            MatchEngineApiGrpc.MatchEngineApiBlockingStub stub = MatchEngineApiGrpc.newBlockingStub(channel);
+            QualityOfServiceGrpc.QualityOfServiceBlockingStub stub = QualityOfServiceGrpc.newBlockingStub(channel);
 
             reply = stub.withDeadlineAfter(mTimeoutInMilliseconds, TimeUnit.MILLISECONDS)
                     .qosPrioritySessionCreate(mRequest);

--- a/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/QosPrioritySessionDelete.java
+++ b/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/QosPrioritySessionDelete.java
@@ -24,9 +24,10 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
-import distributed_match_engine.AppClient.QosPrioritySessionDeleteRequest;
-import distributed_match_engine.AppClient.QosPrioritySessionDeleteReply;
+import distributed_match_engine.Qos.QosPrioritySessionDeleteRequest;
+import distributed_match_engine.Qos.QosPrioritySessionDeleteReply;
 import distributed_match_engine.MatchEngineApiGrpc;
+import distributed_match_engine.QualityOfServiceGrpc;
 import io.grpc.ManagedChannel;
 import io.grpc.StatusRuntimeException;
 
@@ -83,7 +84,7 @@ public class QosPrioritySessionDelete implements Callable {
             Network network = nm.getCellularNetworkOrWifiBlocking(false, mMatchingEngine.getMccMnc(mMatchingEngine.mContext));
 
             channel = mMatchingEngine.channelPicker(mHost, mPort, network);
-            MatchEngineApiGrpc.MatchEngineApiBlockingStub stub = MatchEngineApiGrpc.newBlockingStub(channel);
+            QualityOfServiceGrpc.QualityOfServiceBlockingStub stub = QualityOfServiceGrpc.newBlockingStub(channel);
 
             reply = stub.withDeadlineAfter(mTimeoutInMilliseconds, TimeUnit.MILLISECONDS)
                     .qosPrioritySessionDelete(mRequest);

--- a/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/RegisterClient.java
+++ b/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/RegisterClient.java
@@ -26,8 +26,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
-import distributed_match_engine.AppClient;
-import distributed_match_engine.MatchEngineApiGrpc;
+import distributed_match_engine.SessionGrpc;
+import distributed_match_engine.SessionOuterClass;
 import io.grpc.ManagedChannel;
 import io.grpc.StatusRuntimeException;
 
@@ -35,7 +35,7 @@ public class RegisterClient implements Callable {
     public static final String TAG = "RegisterClient";
 
     private MatchingEngine mMatchingEngine;
-    private AppClient.RegisterClientRequest mRequest;
+    private SessionOuterClass.RegisterClientRequest mRequest;
     private String mHost = null;
     private int mPort = 0;
     private long mTimeoutInMilliseconds = -1;
@@ -44,7 +44,7 @@ public class RegisterClient implements Callable {
         mMatchingEngine = matchingEngine;
     }
 
-    public boolean setRequest(AppClient.RegisterClientRequest request, String host, int port, long timeoutInMilliseconds) {
+    public boolean setRequest(SessionOuterClass.RegisterClientRequest request, String host, int port, long timeoutInMilliseconds) {
         if (request == null) {
             throw new IllegalArgumentException("Request object must not be null.");
         } else if (!MatchingEngine.isMatchingEngineLocationAllowed()) {
@@ -67,19 +67,19 @@ public class RegisterClient implements Callable {
         return true;
     }
 
-    private AppClient.RegisterClientRequest.Builder appendDeviceDetails(AppClient.RegisterClientRequest.Builder builder) {
+    private SessionOuterClass.RegisterClientRequest.Builder appendDeviceDetails(SessionOuterClass.RegisterClientRequest.Builder builder) {
         HashMap<String, String> map = mMatchingEngine.getDeviceInfo();
         builder.putAllTags(map);
         return builder;
     }
 
     @Override
-    public AppClient.RegisterClientReply call() throws MissingRequestException, StatusRuntimeException, InterruptedException, ExecutionException {
+    public SessionOuterClass.RegisterClientReply call() throws MissingRequestException, StatusRuntimeException, InterruptedException, ExecutionException {
         if (mRequest == null) {
             throw new MissingRequestException("Usage error: RegisterClient() does not have a request object to make call!");
         }
 
-        AppClient.RegisterClientReply reply;
+        SessionOuterClass.RegisterClientReply reply;
         ManagedChannel channel = null;
         NetworkManager nm;
         Network network;
@@ -88,9 +88,9 @@ public class RegisterClient implements Callable {
             network = nm.getCellularNetworkOrWifiBlocking(false, mMatchingEngine.getMccMnc(mMatchingEngine.mContext));
 
             channel = mMatchingEngine.channelPicker(mHost, mPort, network);
-            MatchEngineApiGrpc.MatchEngineApiBlockingStub stub = MatchEngineApiGrpc.newBlockingStub(channel);
+            SessionGrpc.SessionBlockingStub stub = SessionGrpc.newBlockingStub(channel);
 
-            AppClient.RegisterClientRequest.Builder builder = AppClient.RegisterClientRequest.newBuilder(mRequest);
+            SessionOuterClass.RegisterClientRequest.Builder builder = SessionOuterClass.RegisterClientRequest.newBuilder(mRequest);
             appendDeviceDetails(builder)
                     .build();
 

--- a/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/VerifyLocation.java
+++ b/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/VerifyLocation.java
@@ -31,10 +31,10 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
-import distributed_match_engine.AppClient;
-import distributed_match_engine.AppClient.VerifyLocationRequest;
-import distributed_match_engine.AppClient.VerifyLocationReply;
-import distributed_match_engine.MatchEngineApiGrpc;
+import distributed_match_engine.LocationGrpc;
+import distributed_match_engine.Locverify;
+import distributed_match_engine.Locverify.VerifyLocationRequest;
+import distributed_match_engine.Locverify.VerifyLocationReply;
 import io.grpc.ManagedChannel;
 import io.grpc.StatusRuntimeException;
 
@@ -113,7 +113,7 @@ public class VerifyLocation implements Callable {
     }
 
     private VerifyLocationRequest addTokenToRequest(String token) {
-        VerifyLocationRequest tokenizedRequest = AppClient.VerifyLocationRequest.newBuilder()
+        VerifyLocationRequest tokenizedRequest = Locverify.VerifyLocationRequest.newBuilder()
                 .setVer(mRequest.getVer())
                 .setSessionCookie(mRequest.getSessionCookie())
                 .setCarrierName(mRequest.getCarrierName())
@@ -144,7 +144,7 @@ public class VerifyLocation implements Callable {
             Network network = nm.getCellularNetworkOrWifiBlocking(false, mMatchingEngine.getMccMnc(mMatchingEngine.mContext));
 
             channel = mMatchingEngine.channelPicker(mHost, mPort, network);
-            MatchEngineApiGrpc.MatchEngineApiBlockingStub stub = MatchEngineApiGrpc.newBlockingStub(channel);
+            LocationGrpc.LocationBlockingStub stub = LocationGrpc.newBlockingStub(channel);
 
             reply = stub.withDeadlineAfter(mTimeoutInMilliseconds, TimeUnit.MILLISECONDS)
                     .verifyLocation(grpcRequest);


### PR DESCRIPTION
A bunch of changes to match the edge-proto file reorg which split the proto files into separate definitions for each API group, resulting in separate Java classes here.